### PR TITLE
Fix passthrough of --name in EXTRA_DOCKER_RUN_ARGS

### DIFF
--- a/tools/cbuild
+++ b/tools/cbuild
@@ -251,7 +251,12 @@ ${DOCKER_RUN_ARGS[*]}
 ${DOCKER_EXEC_RUN_ARGS[*]}
 EOF
 } | sha256sum)"
-  printf "cbuild-%s-%s-%s" "${mount:0:7}" "${image_sha:0:7}" "${docker_args_sha:0:7}"
+  CONTAINER_NAME_PREFIX="cbuild"
+  CONTAINER_NAME_PREFIX_REGEX="--name=([0-9a-zA-Z-]*)"
+  if [[ " ${EXTRA_DOCKER_RUN_ARGS} " =~ $CONTAINER_NAME_PREFIX_REGEX ]]; then
+      CONTAINER_NAME_PREFIX=${BASH_REMATCH[1]}
+  fi
+  printf "%s-%s-%s-%s" "${CONTAINER_NAME_PREFIX}" "${mount:0:7}" "${image_sha:0:7}" "${docker_args_sha:0:7}"
 }
 
 DOCKER_CONTAINER_NAME="$(get_container_name)"


### PR DESCRIPTION
When EXTRA_DOCKER_RUN_ARGS is used and includes the `--name` option it is overwritten by cbuild and the docker container uses a generated name. This uses whatever is set in the env var as a prefix instead of the hardcoded "cbuild" prefix.